### PR TITLE
feat: Sync IDB reviews with server reviews

### DIFF
--- a/src/js/dbhelper.js
+++ b/src/js/dbhelper.js
@@ -305,6 +305,10 @@ class DBHelper {
         `${DBHelper.DATABASE_URL}/reviews?restaurant_id=${id}`
       );
       const reviews = await res.json();
+      // clearing the items of reviews store to stay
+      // in sync with server's data
+      // (i.e. if another user deletes a review <future feature>)
+      await this.idbHelper.clearStore('reviews');
       // add newly fetched reviews to 'reviews' store
       this.idbHelper.putItemsToStore(reviews, 'reviews');
 

--- a/src/js/idbHelper.js
+++ b/src/js/idbHelper.js
@@ -160,13 +160,34 @@ export default class IDBHelper {
   async deleteItemFromStore(storeName, key) {
     try {
       const db = await this.idbPromise;
-      if (!db) if (!db) return;
+      if (!db) return;
 
       const tx = db.transaction(storeName, 'readwrite');
       const store = tx.objectStore(storeName);
 
       store.delete(key);
       console.log(`Deleted one item from ${storeName} store with key=${key}`);
+
+      return tx.complete;
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  /**
+   * Clears the content of an IDB store
+   * @param {String} storeName - The name of the store to clear
+   */
+  async clearStore(storeName) {
+    try {
+      const db = await this.idbPromise;
+      if (!db) return;
+
+      const tx = db.transaction(storeName, 'readwrite');
+      const store = tx.objectStore(storeName);
+
+      store.clear();
+      console.log(`Cleared ${storeName} store`);
 
       return tx.complete;
     } catch (err) {


### PR DESCRIPTION
Incase another user deletes a review <future_feature> we don't wan't to keep the staled data, that's why we clear the reviews store, then add the newly fetched reviews, but only when the latter (fetched reviews) has been successfully fetched.